### PR TITLE
Refactor shell scripts and update readme styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,102 +1,107 @@
-# Uni-Fold: Training your own deep protein-folding models.
+# Uni-Fold: Training your own deep protein-folding models
 
 This package provides an implementation of a trainable, Transformer-based deep protein folding model. We modified the open-source code of DeepMind AlphaFold v2.0 and provided code to train the model from scratch. See the [reference](https://doi.org/10.1038/s41586-021-03819-2) and the [repository](https://github.com/deepmind/alphafold) of DeepMind AlphaFold v2.0. To train your own Uni-Fold models, please follow the steps below:
 
-## 1. Install the environment.
+## 1. Install the environment
 
 Run the following code to install the dependencies of Uni-Fold:
 
 ```bash
-  conda create -n unifold python=3.8.10 -y
-  conda activate unifold
-  ./install_dependencies.sh
-``` 
+conda create -n unifold python=3.8.10 -y
+conda activate unifold
+./install_dependencies.sh
+```
 
 Uni-Fold has been tested for Python 3.8.10, CUDA 11.1 and OpenMPI 4.1.1. We recommend using Conda >= 4.10 to install the environment: using Conda with lower versions may lead to some conflicts between packages.
 
-## 2. Prepare data before training.
+## 2. Prepare data before training
 
 Before you start to train your own folding models, you shall prepare the features and labels of the training proteins. Features of proteins mainly include the amino acid sequence, MSAs and templates of proteins. These messages should be contained in a pickle file `<name>/features.pkl` for each training protein. Uni-Fold provides scripts to process input FASTA files, relying on several external databases and tools. Labels are CIF files containing the structures of the proteins.
 
-### 2.1 Datasets and external tools.
+### 2.1 Datasets and external tools
 
 Uni-Fold adopts the same data processing pipeline as AlphaFold2. We kept the scripts of downloading corresponding databases for searching sequence homologies and templates in the AlphaFold2 repo. Use the command
 
 ```bash
-  bash scripts/download_all_data.sh /path/to/database/directory
+bash scripts/download_all_data.sh /path/to/database/directory
 ```
 
 to download all required databases of Uni-Fold.
 
 If you successfully installed the Conda environment in Section 1, external tools of search sequence homologies and templates should be installed properly. As an alternative, you can customize the arguments of the feature preparation script (`generate_pkl_features.py`) to refer to your own databases and tools.
 
-### 2.2 Run the preparation code.
+### 2.2 Run the preparation code
 
 An example command of running the feature preparation pipeline would be
 
 ```bash
-  python generate_pkl_features.py \
-    --fasta_dir ./example_data/fasta \
-    --output_dir ./out \
-    --data_dir /path/to/database/directory \
-    --num_workers 1
+python generate_pkl_features.py \
+  --fasta_dir ./example_data/fasta \
+  --output_dir ./out \
+  --data_dir /path/to/database/directory \
+  --num_workers 1
 ```
 
 This command automatically processes all FASTA files under `fasta_dir`, and dumps the results to `output_dir`. Note that each FASTA file should contain only one sequence. The default number of CPUs used in hhblits and jackhmmer are 4 and 8. You can modify them in `unifold/data/tools/hhblits.py` and `unifold/data/tools/jackhmmer.py`, respectively.
 
-### 2.3 Organize your training data.
+### 2.3 Organize your training data
 
 Uni-Fold uses the class [`DataSystem`](./unifold/train/data_system.py) to automatically sample and load the training proteins. To make everything goes right, you shall pay attention to how the training data is organized. Two directories should be established, one with input features (`features.pkl` files, referred to as `features_dir`) and the other with labels (`*.cif` files, referred to as `mmcif_dir`). The feature directory should have its files named as `<pdb_id>_<model_id>_<chain_id>/features.pkl`, e.g. `1ak0_1_A/features.pkl`, and the label directory should have its files named as `<pdb_id>.cif`, e.g. `1ak0.cif`. See [`./example_data/features`](./example_data/features) and [`./example_data/mmcif`](./example_data/mmcif) for instances of the two directories. Notably, users shall make sure that all proteins used for training have their corresponding labels. This is checked by `DataSystem.check_completeness()`.
 
-## 3. Train Uni-Fold.
+## 3. Train Uni-Fold
 
-### 3.1 Configuration.
+### 3.1 Configuration
+
 Before you conduct any actual training processes, please make sure that you correctly configured the code. Modify the training configurations in [`unifold/train/train_config.py`](./unifold/train/train_config.py). We annotated the default configurations to reproduce AlphaFold in the script. Specifically, modify the configurations of data paths:
-    
-  ```json
-  "data": {
-    "train": {
-      "features_dir": "where/training/protein/features/are/stored/",
-      "mmcif_dir": "where/training/mmcif/files/are/stored/",
-      "sample_weights": "which/specifies/proteins/for/training.json"
-    },
-    "eval": {
-      "features_dir": "where/validation/protein/features/are/stored/",
-      "mmcif_dir": "where/validation/mmcif/files/are/stored/",
-      "sample_weights": "which/specifies/proteins/for/training.json"
-    }
+
+```json
+"data": {
+  "train": {
+    "features_dir": "where/training/protein/features/are/stored/",
+    "mmcif_dir": "where/training/mmcif/files/are/stored/",
+    "sample_weights": "which/specifies/proteins/for/training.json"
+  },
+  "eval": {
+    "features_dir": "where/validation/protein/features/are/stored/",
+    "mmcif_dir": "where/validation/mmcif/files/are/stored/",
+    "sample_weights": "which/specifies/proteins/for/training.json"
   }
-  ```
-  
-  The specified data should be contained in two folders, namely a `features_dir` and a `mmcif_dir`. Organizations of the two directories are introduced in Section 2.3. Meanwhile, if you want to specify a subset of training data under the directories, or assign customized sample weights for each protein, write a json file and feed its path to `sample_weights`. This is optional, as you can leave it as `None` (and the program will attempt to use all entries under `features_dir` with uniform weights). The json file should be a dictionary containing the basenames of directories of protein features ([pdb_id]\_[model_id]\_[chain_id]) and the sample weight of each protein in the training process (integer or float), such as:
+}
+```
 
-  ```json
-  {"1am9_1_C": 82, "1amp_1_A": 291, "1aoj_1_A": 60, "1aoz_1_A": 552}
-  ```
-  or for uniform sampling, simply using a list of protein entries suffices:
+The specified data should be contained in two folders, namely a `features_dir` and a `mmcif_dir`. Organizations of the two directories are introduced in Section 2.3. Meanwhile, if you want to specify a subset of training data under the directories, or assign customized sample weights for each protein, write a json file and feed its path to `sample_weights`. This is optional, as you can leave it as `None` (and the program will attempt to use all entries under `features_dir` with uniform weights). The json file should be a dictionary containing the basenames of directories of protein features ([pdb_id]\_[model_id]\_[chain_id]) and the sample weight of each protein in the training process (integer or float), such as:
 
-  ```json
-  ["1am9_1_C", "1amp_1_A", "1aoj_1_A", "1aoz_1_A"]
-  ```
+```json
+{"1am9_1_C": 82, "1amp_1_A": 291, "1aoj_1_A": 60, "1aoz_1_A": 552}
+```
 
-For users who want to customize their own folding models, configurations of model hyperparameters can be edited in [`unifold/model/config.py`](./unifold/model/config.py) .
+or for uniform sampling, simply using a list of protein entries suffices:
 
-### 3.2 Run the training code!
+```json
+["1am9_1_C", "1amp_1_A", "1aoj_1_A", "1aoz_1_A"]
+```
+
+For users who want to customize their own folding models, configurations of model hyperparameters can be edited in [`unifold/model/config.py`](./unifold/model/config.py).
+
+### 3.2 Run the training code
+
 To train the model on a single node without MPI, run
+
 ```bash
 python train.py
 ```
 
 You can also train the model with multiple GPUs using MPI (or workload managers that supports MPI, such as PBS or Slurm) by running:
+
 ```bash
 mpirun -n <num_of_gpus> python train.py
 ```
 
 In either way, make sure you properly configurate the option `use_mpi` and `gpus_per_node` in [`unifold/train/train_config.py`](./unifold/train/train_config.py).
 
-## 4. Infer with trained models.
+## 4. Infer with trained models
 
-### 4.1 Infer from features.pkl.
+### 4.1 Infer from features.pkl
 
 We provide the [`run_from_pkl.py`](./run_from_pkl.py) script to support inferring protein structures from `features.pkl` inputs. A demo command would be
 
@@ -120,7 +125,7 @@ python run_from_pkl.py \
 
 The command will generate structures (in PDB format) from input features predicted by different input models, the running time of each component, and corresponding residue-wise confidence score (predicted LDDT, or pLDDT).
 
-### 4.2 Infer from FASTA files.
+### 4.2 Infer from FASTA files
 
 Essentially, inferring the structures from given FASTA files includes two steps, i.e. generating the pickled features and predicting structures from them. We provided a script, [`run_from_fasta.py`](./run_from_fasta.py), as a friendlier user interface. An example usage would be
 
@@ -133,18 +138,17 @@ python run_from_pkl.py \
   --output_dir ./out
 ```
 
-### 4.3 Generate MSAs with MMseqs2.
+### 4.3 Generate MSAs with MMseqs2
 
 It may take hours and much memory to generate MSA for sequences, especially for long sequences. In this condition, MMseqs2 may be a more efficient way. It can be used in the following way after it is [installed](https://github.com/soedinglab/mmseqs2/wiki#installation):
 
 ```bash
-
 # download and build database
 mkdir mmseqs_db && cd mmseqs_db
 wget http://wwwuser.gwdg.de/~compbiol/colabfold/uniref30_2103.tar.gz
 wget http://wwwuser.gwdg.de/~compbiol/colabfold/colabfold_envdb_202108.tar.gz
-tar xzvf uniref30_2103.tar.gz
-tar xzvf colabfold_envdb_202108.tar.gz
+tar -xvzf uniref30_2103.tar.gz
+tar -xvzf colabfold_envdb_202108.tar.gz
 mmseqs tsv2exprofiledb uniref30_2103 uniref30_2103_db
 mmseqs tsv2exprofiledb colabfold_envdb_202108 colabfold_envdb_202108_db
 mmseqs createindex uniref30_2103_db tmp
@@ -153,9 +157,9 @@ cd ..
 
 # MSA search
 ./scripts/colabfold_search.sh mmseqs "query.fasta" "mmseqs_db/" "result/" "uniref30_2103_db" "" "colabfold_envdb_202108_db" "1" "0" "1"
-
 ```
-## 5. Changes from AlphaFold to Uni-Fold.
+
+## 5. Changes from AlphaFold to Uni-Fold
 
 - We implemented classes and methods for training and inference pipelines by adding scripts under `unifold/train` and `unifold/inference`.
 - We added scripts for installing the environment, training and inferencing.
@@ -163,15 +167,15 @@ cd ..
 - Files under `unifold/model` are slightly altered to allow mixed-precision training.
 - We removed some unused scripts in training AlphaFold model.
 
-## 6. License and disclaimer.
+## 6. License and disclaimer
 
-### 6.1 Uni-Fold code license.
+### 6.1 Uni-Fold code license
 
 Copyright 2021 Beijing DP Technology Co., Ltd.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
-You may obtain a copy of the License at 
+You may obtain a copy of the License at
 <http://www.apache.org/licenses/LICENSE-2.0>.
 
 Unless required by applicable law or agreed to in writing, software
@@ -180,11 +184,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-### 6.2 Use of third-party software.
+### 6.2 Use of third-party software
 
 Use of the third-party software, libraries or code may be governed by separate terms and conditions or license provisions. Your use of the third-party software, libraries or code is subject to any such terms and you should check that you can comply with any applicable restrictions or terms and conditions before use.
 
-### 6.3 Contributing to Uni-Fold.
+### 6.3 Contributing to Uni-Fold
 
 Uni-Fold is an ongoing project. Our target is to design better protein folding models and to apply them in real scenarios.
 We welcome the community to join us in developing the repository together, including but not limited to 1) reports and fixes of bugs,2) new features and 3) better interfaces. Please refer to [`CONTRIBUTING.md`](./CONTRIBUTING.md) for more information.

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# 
+#
 # Copyright 2021 Beijing DP Technology Co., Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,28 +26,26 @@ conda install -y -c conda-forge openmm=7.5.1 pdbfixer cudatoolkit=11.1
 conda install -y -c bioconda hmmer hhsuite==3.3.0 kalign2
 
 # update openmm
-work_path=$(pwd)
-python_path=$(which python)
-cd $(dirname $(dirname $python_path))/lib/python3.8/site-packages
-patch -p0 < $work_path/openmm.patch
-cd $work_path
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+SITE_PACKAGES_DIR="$(python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')" # path to /path/to/conda/envs/XXX/lib/pythonX.Y/site-packages
+patch -d "${SITE_PACKAGES_DIR}" -p0 <"${SCRIPT_DIR}/openmm.patch"
 
 #######################################
 # dependencies of training Uni-Fold   #
 #######################################
 
 # install openmpi
-wget https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.1.tar.gz
-gunzip -c openmpi-4.1.1.tar.gz | tar xf -
-cd openmpi-4.1.1
-./configure --prefix=/usr/local
-make all install
-cd ..
+wget -O - https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.1.tar.gz |
+  tar -xz --strip-components=1 --one-top-level=openmpi &&
+  (
+    cd openmpi &&
+      ./configure --prefix=/usr/local &&
+      make all install
+  )
 
 # install conda and pip packages
 conda install -y -c nvidia cudnn==8.0.4
-pip install --upgrade pip \
-    && pip install -r ./requirements.txt \
-    && pip install jaxlib==0.1.67+cuda111 -f \
+pip install --upgrade pip &&
+  pip install -r ./requirements.txt &&
+  pip install jaxlib==0.1.67+cuda111 -f \
     https://storage.googleapis.com/jax-releases/jax_releases.html
-

--- a/scripts/colabfold_search.sh
+++ b/scripts/colabfold_search.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 
 # Copyright 2021 Beijing DP Technology Co., Ltd.
 #
@@ -16,56 +16,63 @@
 
 # Searching for MSA with MMSeqs2.
 
-MMSEQS="$1"
-QUERY="$2"
-DBBASE="$3"
-BASE="$4"
-DB1="$5"
-DB2="$6"
-DB3="$7"
-USE_ENV="$8"
-USE_TEMPLATES="$9"
+set -e
+
+MMSEQS="${1}"
+QUERY="${2}"
+DBBASE="${3}"
+BASE="${4}"
+DB1="${5}"
+DB2="${6}"
+DB3="${7}"
+USE_ENV="${8}"
+USE_TEMPLATES="${9}"
 FILTER="${10}"
 EXPAND_EVAL=inf
 ALIGN_EVAL=10
 DIFF=3000
 QSC=-20.0
 MAX_ACCEPT=1000000
-if [ "${FILTER}" = "1" ]; then
-# 0.1 was not used in benchmarks due to POSIX shell bug in line above
-#  EXPAND_EVAL=0.1
+if [[ "${FILTER}" == "1" ]]; then
+  # 0.1 was not used in benchmarks due to POSIX shell bug in line above
+  #   EXPAND_EVAL=0.1
   ALIGN_EVAL=10
   QSC=0.8
   MAX_ACCEPT=100000
 fi
 export MMSEQS_CALL_DEPTH=1
-SEARCH_PARAM="--num-iterations 3 --db-load-mode 2 -a -s 8 -e 0.1 --max-seqs 10000"
-FILTER_PARAM="--filter-msa ${FILTER} --filter-min-enable 1000 --diff ${DIFF} --qid 0.0,0.2,0.4,0.6,0.8,1.0 --qsc 0 --max-seq-id 0.95"
-EXPAND_PARAM="--expansion-mode 0 -e ${EXPAND_EVAL} --expand-filter-clusters ${FILTER} --max-seq-id 0.95"
+
+SEARCH_PARAM=("--num-iterations" "3" "--db-load-mode" "2" "-a" "-s" "8" "-e" "0.1" "--max-seqs" "10000")
+FILTER_PARAM=("--filter-msa" "${FILTER}" "--filter-min-enable" "1000" "--diff" "${DIFF}" "--qid" "0.0,0.2,0.4,0.6,0.8,1.0" "--qsc" "0" "--max-seq-id" "0.95")
+EXPAND_PARAM=("--expansion-mode" "0" "-e" "${EXPAND_EVAL}" "--expand-filter-clusters" "${FILTER}" "--max-seq-id" "0.95")
+
 mkdir -p "${BASE}"
+
 "${MMSEQS}" createdb "${QUERY}" "${BASE}/qdb"
-"${MMSEQS}" search "${BASE}/qdb" "${DBBASE}/${DB1}" "${BASE}/res" "${BASE}/tmp" $SEARCH_PARAM
-"${MMSEQS}" expandaln "${BASE}/qdb" "${DBBASE}/${DB1}.idx" "${BASE}/res" "${DBBASE}/${DB1}.idx" "${BASE}/res_exp" --db-load-mode 2 ${EXPAND_PARAM}
+"${MMSEQS}" search "${BASE}/qdb" "${DBBASE}/${DB1}" "${BASE}/res" "${BASE}/tmp" "${SEARCH_PARAM[@]}"
+"${MMSEQS}" expandaln "${BASE}/qdb" "${DBBASE}/${DB1}.idx" "${BASE}/res" "${DBBASE}/${DB1}.idx" "${BASE}/res_exp" --db-load-mode 2 "${EXPAND_PARAM[@]}"
 "${MMSEQS}" mvdb "${BASE}/tmp/latest/profile_1" "${BASE}/prof_res"
 "${MMSEQS}" lndb "${BASE}/qdb_h" "${BASE}/prof_res_h"
-"${MMSEQS}" align "${BASE}/prof_res" "${DBBASE}/${DB1}.idx" "${BASE}/res_exp" "${BASE}/res_exp_realign" --db-load-mode 2 -e ${ALIGN_EVAL} --max-accept ${MAX_ACCEPT} --alt-ali 10 -a
+"${MMSEQS}" align "${BASE}/prof_res" "${DBBASE}/${DB1}.idx" "${BASE}/res_exp" "${BASE}/res_exp_realign" --db-load-mode 2 -e "${ALIGN_EVAL}" --max-accept "${MAX_ACCEPT}" --alt-ali 10 -a
 "${MMSEQS}" filterresult "${BASE}/qdb" "${DBBASE}/${DB1}.idx" "${BASE}/res_exp_realign" "${BASE}/res_exp_realign_filter" --db-load-mode 2 --qid 0 --qsc $QSC --diff 0 --max-seq-id 1.0 --filter-min-enable 100
-"${MMSEQS}" result2msa "${BASE}/qdb" "${DBBASE}/${DB1}.idx" "${BASE}/res_exp_realign_filter" "${BASE}/uniref.a3m" --msa-format-mode 6 --db-load-mode 2 ${FILTER_PARAM}
+"${MMSEQS}" result2msa "${BASE}/qdb" "${DBBASE}/${DB1}.idx" "${BASE}/res_exp_realign_filter" "${BASE}/uniref.a3m" --msa-format-mode 6 --db-load-mode 2 "${FILTER_PARAM[@]}"
 "${MMSEQS}" rmdb "${BASE}/res_exp_realign"
 "${MMSEQS}" rmdb "${BASE}/res_exp"
 "${MMSEQS}" rmdb "${BASE}/res"
 "${MMSEQS}" rmdb "${BASE}/res_exp_realign_filter"
-if [ "${USE_TEMPLATES}" = "1" ]; then
+
+if [[ "${USE_TEMPLATES}" == "1" ]]; then
   "${MMSEQS}" search "${BASE}/prof_res" "${DBBASE}/${DB2}" "${BASE}/res_pdb" "${BASE}/tmp" --db-load-mode 2 -s 7.5 -a -e 0.1
   "${MMSEQS}" convertalis "${BASE}/prof_res" "${DBBASE}/${DB2}.idx" "${BASE}/res_pdb" "${BASE}/${DB2}.m8" --format-output query,target,fident,alnlen,mismatch,gapopen,qstart,qend,tstart,tend,evalue,bits,cigar --db-load-mode 2
   "${MMSEQS}" rmdb "${BASE}/res_pdb"
 fi
-if [ "${USE_ENV}" = "1" ]; then
-  "${MMSEQS}" search "${BASE}/prof_res" "${DBBASE}/${DB3}" "${BASE}/res_env" "${BASE}/tmp" $SEARCH_PARAM
-  "${MMSEQS}" expandaln "${BASE}/prof_res" "${DBBASE}/${DB3}.idx" "${BASE}/res_env" "${DBBASE}/${DB3}.idx" "${BASE}/res_env_exp" -e ${EXPAND_EVAL} --expansion-mode 0 --db-load-mode 2
-  "${MMSEQS}" align "${BASE}/tmp/latest/profile_1" "${DBBASE}/${DB3}.idx" "${BASE}/res_env_exp" "${BASE}/res_env_exp_realign" --db-load-mode 2 -e ${ALIGN_EVAL} --max-accept ${MAX_ACCEPT} --alt-ali 10 -a
+
+if [[ "${USE_ENV}" == "1" ]]; then
+  "${MMSEQS}" search "${BASE}/prof_res" "${DBBASE}/${DB3}" "${BASE}/res_env" "${BASE}/tmp" "${SEARCH_PARAM[@]}"
+  "${MMSEQS}" expandaln "${BASE}/prof_res" "${DBBASE}/${DB3}.idx" "${BASE}/res_env" "${DBBASE}/${DB3}.idx" "${BASE}/res_env_exp" -e "${EXPAND_EVAL}" --expansion-mode 0 --db-load-mode 2
+  "${MMSEQS}" align "${BASE}/tmp/latest/profile_1" "${DBBASE}/${DB3}.idx" "${BASE}/res_env_exp" "${BASE}/res_env_exp_realign" --db-load-mode 2 -e "${ALIGN_EVAL}" --max-accept "${MAX_ACCEPT}" --alt-ali 10 -a
   "${MMSEQS}" filterresult "${BASE}/qdb" "${DBBASE}/${DB3}.idx" "${BASE}/res_env_exp_realign" "${BASE}/res_env_exp_realign_filter" --db-load-mode 2 --qid 0 --qsc $QSC --diff 0 --max-seq-id 1.0 --filter-min-enable 100
-  "${MMSEQS}" result2msa "${BASE}/qdb" "${DBBASE}/${DB3}.idx" "${BASE}/res_env_exp_realign_filter" "${BASE}/bfd.mgnify30.metaeuk30.smag30.a3m" --msa-format-mode 6 --db-load-mode 2 ${FILTER_PARAM}
+  "${MMSEQS}" result2msa "${BASE}/qdb" "${DBBASE}/${DB3}.idx" "${BASE}/res_env_exp_realign_filter" "${BASE}/bfd.mgnify30.metaeuk30.smag30.a3m" --msa-format-mode 6 --db-load-mode 2 "${FILTER_PARAM[@]}"
   "${MMSEQS}" rmdb "${BASE}/res_env_exp_realign_filter"
   "${MMSEQS}" rmdb "${BASE}/res_env_exp_realign"
   "${MMSEQS}" rmdb "${BASE}/res_env_exp"
@@ -74,5 +81,6 @@ fi
 "${MMSEQS}" rmdb "${BASE}/qdb"
 "${MMSEQS}" rmdb "${BASE}/qdb_h"
 "${MMSEQS}" rmdb "${BASE}/res"
+
 rm -f -- "${BASE}/prof_res"*
 rm -rf -- "${BASE}/tmp"

--- a/scripts/download_all_data.sh
+++ b/scripts/download_all_data.sh
@@ -17,22 +17,22 @@
 # Downloads and unzips all required data for Uni-Fold.
 #
 # Usage: bash download_all_data.sh /path/to/download/directory
+
 set -e
 
 if [[ $# -eq 0 ]]; then
-    echo "Error: download directory must be provided as an input argument."
-    exit 1
+  echo "Error: download directory must be provided as an input argument."
+  exit 1
 fi
 
-if ! command -v aria2c &> /dev/null ; then
-    echo "Error: aria2c could not be found. Please install aria2c (sudo apt install aria2)."
-    exit 1
+if ! command -v aria2c &>/dev/null; then
+  echo "Error: aria2c could not be found. Please install aria2c (sudo apt install aria2)."
+  exit 1
 fi
 
 DOWNLOAD_DIR="$1"
 DOWNLOAD_MODE="${2:-full_dbs}" # Default mode to full_dbs.
-if [[ "${DOWNLOAD_MODE}"  != full_dbs && "${DOWNLOAD_MODE}" != reduced_dbs ]]
-then
+if [[ "${DOWNLOAD_MODE}" != "full_dbs" && "${DOWNLOAD_MODE}" != "reduced_dbs" ]]; then
   echo "DOWNLOAD_MODE ${DOWNLOAD_MODE} not recognized."
   exit 1
 fi
@@ -42,7 +42,7 @@ SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 # echo "Downloading AlphaFold parameters..."
 # bash "${SCRIPT_DIR}/download_alphafold_params.sh" "${DOWNLOAD_DIR}"
 
-if [[ "${DOWNLOAD_MODE}" = full_dbs ]] ; then
+if [[ "${DOWNLOAD_MODE}" == "full_dbs" ]]; then
   echo "Downloading BFD..."
   bash "${SCRIPT_DIR}/download_bfd.sh" "${DOWNLOAD_DIR}"
 else

--- a/scripts/download_alphafold_params.sh
+++ b/scripts/download_alphafold_params.sh
@@ -17,25 +17,25 @@
 # Downloads and unzips the AlphaFold parameters.
 #
 # Usage: bash download_alphafold_params.sh /path/to/download/directory
+
 set -e
 
 if [[ $# -eq 0 ]]; then
-    echo "Error: download directory must be provided as an input argument."
-    exit 1
+  echo "Error: download directory must be provided as an input argument."
+  exit 1
 fi
 
-if ! command -v aria2c &> /dev/null ; then
-    echo "Error: aria2c could not be found. Please install aria2c (sudo apt install aria2)."
-    exit 1
+if ! command -v aria2c &>/dev/null; then
+  echo "Error: aria2c could not be found. Please install aria2c (sudo apt install aria2)."
+  exit 1
 fi
 
 DOWNLOAD_DIR="$1"
 ROOT_DIR="${DOWNLOAD_DIR}/params"
 SOURCE_URL="https://storage.googleapis.com/alphafold/alphafold_params_2021-07-14.tar"
-BASENAME=$(basename "${SOURCE_URL}")
+BASENAME="$(basename "${SOURCE_URL}")"
 
-mkdir --parents "${ROOT_DIR}"
+mkdir -p "${ROOT_DIR}"
 aria2c "${SOURCE_URL}" --dir="${ROOT_DIR}"
-tar --extract --verbose --file="${ROOT_DIR}/${BASENAME}" \
-  --directory="${ROOT_DIR}" --preserve-permissions
+tar -xpvf "${ROOT_DIR}/${BASENAME}" -C "${ROOT_DIR}"
 rm "${ROOT_DIR}/${BASENAME}"

--- a/scripts/download_bfd.sh
+++ b/scripts/download_bfd.sh
@@ -17,16 +17,17 @@
 # Downloads and unzips the BFD database for Uni-Fold.
 #
 # Usage: bash download_bfd.sh /path/to/download/directory
+
 set -e
 
 if [[ $# -eq 0 ]]; then
-    echo "Error: download directory must be provided as an input argument."
-    exit 1
+  echo "Error: download directory must be provided as an input argument."
+  exit 1
 fi
 
-if ! command -v aria2c &> /dev/null ; then
-    echo "Error: aria2c could not be found. Please install aria2c (sudo apt install aria2)."
-    exit 1
+if ! command -v aria2c &>/dev/null; then
+  echo "Error: aria2c could not be found. Please install aria2c (sudo apt install aria2)."
+  exit 1
 fi
 
 DOWNLOAD_DIR="$1"
@@ -34,10 +35,9 @@ ROOT_DIR="${DOWNLOAD_DIR}/bfd"
 # Mirror of:
 # https://bfd.mmseqs.com/bfd_metaclust_clu_complete_id30_c90_final_seq.sorted_opt.tar.gz.
 SOURCE_URL="https://storage.googleapis.com/alphafold-databases/casp14_versions/bfd_metaclust_clu_complete_id30_c90_final_seq.sorted_opt.tar.gz"
-BASENAME=$(basename "${SOURCE_URL}")
+BASENAME="$(basename "${SOURCE_URL}")"
 
-mkdir --parents "${ROOT_DIR}"
+mkdir -p "${ROOT_DIR}"
 aria2c "${SOURCE_URL}" --dir="${ROOT_DIR}"
-tar --extract --verbose --file="${ROOT_DIR}/${BASENAME}" \
-  --directory="${ROOT_DIR}"
+tar -xpvzf "${ROOT_DIR}/${BASENAME}" -C "${ROOT_DIR}"
 rm "${ROOT_DIR}/${BASENAME}"

--- a/scripts/download_mgnify.sh
+++ b/scripts/download_mgnify.sh
@@ -17,16 +17,17 @@
 # Downloads and unzips the MGnify database for Uni-Fold.
 #
 # Usage: bash download_mgnify.sh /path/to/download/directory
+
 set -e
 
 if [[ $# -eq 0 ]]; then
-    echo "Error: download directory must be provided as an input argument."
-    exit 1
+  echo "Error: download directory must be provided as an input argument."
+  exit 1
 fi
 
-if ! command -v aria2c &> /dev/null ; then
-    echo "Error: aria2c could not be found. Please install aria2c (sudo apt install aria2)."
-    exit 1
+if ! command -v aria2c &>/dev/null; then
+  echo "Error: aria2c could not be found. Please install aria2c (sudo apt install aria2)."
+  exit 1
 fi
 
 DOWNLOAD_DIR="$1"
@@ -34,9 +35,9 @@ ROOT_DIR="${DOWNLOAD_DIR}/mgnify"
 # Mirror of:
 # ftp://ftp.ebi.ac.uk/pub/databases/metagenomics/peptide_database/2018_12/mgy_clusters.fa.gz
 SOURCE_URL="https://storage.googleapis.com/alphafold-databases/casp14_versions/mgy_clusters_2018_12.fa.gz"
-BASENAME=$(basename "${SOURCE_URL}")
+BASENAME="$(basename "${SOURCE_URL}")"
 
-mkdir --parents "${ROOT_DIR}"
+mkdir -p "${ROOT_DIR}"
 aria2c "${SOURCE_URL}" --dir="${ROOT_DIR}"
 pushd "${ROOT_DIR}"
 gunzip "${ROOT_DIR}/${BASENAME}"

--- a/scripts/download_pdb70.sh
+++ b/scripts/download_pdb70.sh
@@ -17,25 +17,25 @@
 # Downloads and unzips the PDB70 database for Uni-Fold.
 #
 # Usage: bash download_pdb70.sh /path/to/download/directory
+
 set -e
 
 if [[ $# -eq 0 ]]; then
-    echo "Error: download directory must be provided as an input argument."
-    exit 1
+  echo "Error: download directory must be provided as an input argument."
+  exit 1
 fi
 
-if ! command -v aria2c &> /dev/null ; then
-    echo "Error: aria2c could not be found. Please install aria2c (sudo apt install aria2)."
-    exit 1
+if ! command -v aria2c &>/dev/null; then
+  echo "Error: aria2c could not be found. Please install aria2c (sudo apt install aria2)."
+  exit 1
 fi
 
 DOWNLOAD_DIR="$1"
 ROOT_DIR="${DOWNLOAD_DIR}/pdb70"
 SOURCE_URL="http://wwwuser.gwdg.de/~compbiol/data/hhsuite/databases/hhsuite_dbs/old-releases/pdb70_from_mmcif_200401.tar.gz"
-BASENAME=$(basename "${SOURCE_URL}")
+BASENAME="$(basename "${SOURCE_URL}")"
 
-mkdir --parents "${ROOT_DIR}"
+mkdir -p "${ROOT_DIR}"
 aria2c "${SOURCE_URL}" --dir="${ROOT_DIR}"
-tar --extract --verbose --file="${ROOT_DIR}/${BASENAME}" \
-  --directory="${ROOT_DIR}"
+tar -xvzf "${ROOT_DIR}/${BASENAME}" -C "${ROOT_DIR}"
 rm "${ROOT_DIR}/${BASENAME}"

--- a/scripts/download_pdb_mmcif.sh
+++ b/scripts/download_pdb_mmcif.sh
@@ -17,21 +17,22 @@
 # Downloads, unzips and flattens the PDB database for Uni-Fold.
 #
 # Usage: bash download_pdb_mmcif.sh /path/to/download/directory
+
 set -e
 
 if [[ $# -eq 0 ]]; then
-    echo "Error: download directory must be provided as an input argument."
-    exit 1
+  echo "Error: download directory must be provided as an input argument."
+  exit 1
 fi
 
-if ! command -v aria2c &> /dev/null ; then
-    echo "Error: aria2c could not be found. Please install aria2c (sudo apt install aria2)."
-    exit 1
+if ! command -v aria2c &>/dev/null; then
+  echo "Error: aria2c could not be found. Please install aria2c (sudo apt install aria2)."
+  exit 1
 fi
 
-if ! command -v rsync &> /dev/null ; then
-    echo "Error: rsync could not be found. Please install rsync."
-    exit 1
+if ! command -v rsync &>/dev/null; then
+  echo "Error: rsync could not be found. Please install rsync."
+  exit 1
 fi
 
 DOWNLOAD_DIR="$1"
@@ -40,7 +41,7 @@ RAW_DIR="${ROOT_DIR}/raw"
 MMCIF_DIR="${ROOT_DIR}/mmcif_files"
 
 echo "Running rsync to fetch all mmCIF files (note that the rsync progress estimate might be inaccurate)..."
-mkdir --parents "${RAW_DIR}"
+mkdir -p "${RAW_DIR}"
 rsync --recursive --links --perms --times --compress --info=progress2 --delete --port=33444 \
   rsync.rcsb.org::ftp_data/structures/divided/mmCIF/ \
   "${RAW_DIR}"
@@ -49,8 +50,8 @@ echo "Unzipping all mmCIF files..."
 find "${RAW_DIR}/" -type f -iname "*.gz" -exec gunzip {} +
 
 echo "Flattening all mmCIF files..."
-mkdir --parents "${MMCIF_DIR}"
-find "${RAW_DIR}" -type d -empty -delete  # Delete empty directories.
+mkdir -p "${MMCIF_DIR}"
+find "${RAW_DIR}" -type d -empty -delete # Delete empty directories.
 for subdir in "${RAW_DIR}"/*; do
   mv "${subdir}/"*.cif "${MMCIF_DIR}"
 done

--- a/scripts/download_small_bfd.sh
+++ b/scripts/download_small_bfd.sh
@@ -17,22 +17,23 @@
 # Downloads and unzips the Small BFD database for Uni-Fold.
 #
 # Usage: bash download_small_bfd.sh /path/to/download/directory
+
 set -e
 
 if [[ $# -eq 0 ]]; then
-    echo "Error: download directory must be provided as an input argument."
-    exit 1
+  echo "Error: download directory must be provided as an input argument."
+  exit 1
 fi
 
-if ! command -v aria2c &> /dev/null ; then
-    echo "Error: aria2c could not be found. Please install aria2c (sudo apt install aria2)."
-    exit 1
+if ! command -v aria2c &>/dev/null; then
+  echo "Error: aria2c could not be found. Please install aria2c (sudo apt install aria2)."
+  exit 1
 fi
 
 DOWNLOAD_DIR="$1"
 ROOT_DIR="${DOWNLOAD_DIR}/small_bfd"
 SOURCE_URL="https://storage.googleapis.com/alphafold-databases/reduced_dbs/bfd-first_non_consensus_sequences.fasta.gz"
-BASENAME=$(basename "${SOURCE_URL}")
+BASENAME="$(basename "${SOURCE_URL}")"
 
 mkdir --parents "${ROOT_DIR}"
 aria2c "${SOURCE_URL}" --dir="${ROOT_DIR}"

--- a/scripts/download_uniclust30.sh
+++ b/scripts/download_uniclust30.sh
@@ -17,16 +17,17 @@
 # Downloads and unzips the Uniclust30 database for Uni-Fold.
 #
 # Usage: bash download_uniclust30.sh /path/to/download/directory
+
 set -e
 
 if [[ $# -eq 0 ]]; then
-    echo "Error: download directory must be provided as an input argument."
-    exit 1
+  echo "Error: download directory must be provided as an input argument."
+  exit 1
 fi
 
-if ! command -v aria2c &> /dev/null ; then
-    echo "Error: aria2c could not be found. Please install aria2c (sudo apt install aria2)."
-    exit 1
+if ! command -v aria2c &>/dev/null; then
+  echo "Error: aria2c could not be found. Please install aria2c (sudo apt install aria2)."
+  exit 1
 fi
 
 DOWNLOAD_DIR="$1"
@@ -34,10 +35,9 @@ ROOT_DIR="${DOWNLOAD_DIR}/uniclust30"
 # Mirror of:
 # http://wwwuser.gwdg.de/~compbiol/uniclust/2018_08/uniclust30_2018_08_hhsuite.tar.gz
 SOURCE_URL="https://storage.googleapis.com/alphafold-databases/casp14_versions/uniclust30_2018_08_hhsuite.tar.gz"
-BASENAME=$(basename "${SOURCE_URL}")
+BASENAME="$(basename "${SOURCE_URL}")"
 
-mkdir --parents "${ROOT_DIR}"
+mkdir -p "${ROOT_DIR}"
 aria2c "${SOURCE_URL}" --dir="${ROOT_DIR}"
-tar --extract --verbose --file="${ROOT_DIR}/${BASENAME}" \
-  --directory="${ROOT_DIR}"
+tar -xvzf "${ROOT_DIR}/${BASENAME}" -C "${ROOT_DIR}"
 rm "${ROOT_DIR}/${BASENAME}"

--- a/scripts/download_uniref90.sh
+++ b/scripts/download_uniref90.sh
@@ -17,24 +17,25 @@
 # Downloads and unzips the UniRef90 database for Uni-Fold.
 #
 # Usage: bash download_uniref90.sh /path/to/download/directory
+
 set -e
 
 if [[ $# -eq 0 ]]; then
-    echo "Error: download directory must be provided as an input argument."
-    exit 1
+  echo "Error: download directory must be provided as an input argument."
+  exit 1
 fi
 
-if ! command -v aria2c &> /dev/null ; then
-    echo "Error: aria2c could not be found. Please install aria2c (sudo apt install aria2)."
-    exit 1
+if ! command -v aria2c &>/dev/null; then
+  echo "Error: aria2c could not be found. Please install aria2c (sudo apt install aria2)."
+  exit 1
 fi
 
 DOWNLOAD_DIR="$1"
 ROOT_DIR="${DOWNLOAD_DIR}/uniref90"
 SOURCE_URL="ftp://ftp.uniprot.org/pub/databases/uniprot/uniref/uniref90/uniref90.fasta.gz"
-BASENAME=$(basename "${SOURCE_URL}")
+BASENAME="$(basename "${SOURCE_URL}")"
 
-mkdir --parents "${ROOT_DIR}"
+mkdir -p "${ROOT_DIR}"
 aria2c "${SOURCE_URL}" --dir="${ROOT_DIR}"
 pushd "${ROOT_DIR}"
 gunzip "${ROOT_DIR}/${BASENAME}"


### PR DESCRIPTION
Commits:

1. refactor shell script `install_dependencies.sh`

    - remove the arbitrary path to `lib/python3.8/site-packages`, support Python versions other than 3.8
    - remove redundant `cd` command
    - extract tarball from `stdin`, reducing auxiliary files

2. refactor shell scripts (`scripts/*.sh`)

    - use arrays to store command-line parameters
    - unify shell script styles, format shell scripts with `shfmt -i 2`
    - refactor command-line options of `tar`

3. update readme (tested with `markdownlint`)

    - remote tailing punctuations in headings
    - add linebreaks around headings and code-blocks
    - remove reduction whitespaces in code-blocks