### PR TITLE
Revert "Bump numpy from 1.19.5 to 1.21.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,6 @@ jmp==0.0.2
 ml-collections==0.1.0
 mpi4jax==0.3.2
 mpi4py==3.1.1
-numpy==1.21.0
+numpy==1.19.5
 scipy==1.7.0
 tensorflow-cpu==2.5.3


### PR DESCRIPTION
Hot fix: The installation was reported to fail when bumping numpy to 1.21.0. We revert this update as a temporary solution. Will update the code to support higher numpy version.