### PR TITLE
optimize the consumption of memory in inference with chunked setting

### DIFF
--- a/unifold/modules/attentions.py
+++ b/unifold/modules/attentions.py
@@ -312,7 +312,7 @@ class MSAColumnGlobalAttention(nn.Module):
     ) -> torch.Tensor:
         return chunk_layer(
             self._attn_forward,
-            {"x": m, "mask": mask},
+            {"m": m, "mask": mask},
             chunk_size=chunk_size,
             num_batch_dims=len(m.shape[:-2]),
         )

--- a/unifold/modules/attentions.py
+++ b/unifold/modules/attentions.py
@@ -141,13 +141,10 @@ class GlobalAttention(nn.Module):
         return self.linear_o(o)
 
 
-def gen_msa_attn_mask(mask, inf, gen_col_mask=True):
+def gen_msa_attn_mask(mask, inf):
     row_mask = gen_attn_mask(mask, -inf)[..., :, None, None, :]
-    if gen_col_mask:
-        col_mask = gen_attn_mask(mask.transpose(-1, -2), -inf)[..., :, None, None, :]
-        return row_mask, col_mask
-    else:
-        return row_mask
+    col_mask = gen_attn_mask(mask.transpose(-1, -2), -inf)[..., :, None, None, :]
+    return row_mask, col_mask
 
 
 class MSAAttention(nn.Module):
@@ -179,34 +176,17 @@ class MSAAttention(nn.Module):
         bias: Optional[torch.Tensor] = None,
         chunk_size: int = None,
     ) -> torch.Tensor:
+
+        def chunk_forward(m, mask, bias: Optional[torch.Tensor] = None):
+            m = self.layer_norm_m(m)
+            return self.mha(q=m, k=m, v=m, mask=mask, bias=bias)
+            
         return chunk_layer(
-            self.mha,
-            {"q": m, "k": m, "v": m, "mask": mask, "bias": bias},
+            chunk_forward,
+            {"m": m, "mask": mask, "bias": bias},
             chunk_size=chunk_size,
             num_batch_dims=len(m.shape[:-2]),
         )
-
-
-    @torch.jit.ignore
-    def _chunk_attn(
-        self,
-        m: torch.Tensor,
-        mask: Optional[torch.Tensor] = None,
-        bias: Optional[torch.Tensor] = None,
-        chunk_size: Optional[int] = 2560,
-    ) -> torch.Tensor:
-        num_chunk = (m.shape[-3] + chunk_size - 1) // chunk_size
-        outputs = []
-        for i in range(num_chunk):
-            chunk_start = i * chunk_size
-            chunk_end  = min(m.shape[-3], chunk_start + chunk_size)
-            cur_m = m[..., chunk_start: chunk_end , :, :]
-            cur_mask = mask[..., chunk_start: chunk_end, :, :, :] if mask is not None else None
-            outputs.append(
-                self.mha(q=cur_m, k=cur_m, v=cur_m, mask=cur_mask, bias=bias)
-            )
-        return torch.concat(outputs, dim=-3)
-
 
     def forward(
         self,
@@ -215,7 +195,7 @@ class MSAAttention(nn.Module):
         attn_mask: Optional[torch.Tensor] = None,
         chunk_size: Optional[int] = None,
     ) -> torch.Tensor:
-        m = self.layer_norm_m(m)
+
 
         bias = None
         if self.pair_bias:
@@ -229,11 +209,8 @@ class MSAAttention(nn.Module):
         if chunk_size is not None:
             m = self._chunk(m, attn_mask, bias, chunk_size)
         else:
-            attn_chunk_size = 2560
-            if m.shape[-3] <= attn_chunk_size:
-                m = self.mha(q=m, k=m, v=m, mask=attn_mask, bias=bias)
-            else:
-                return self._chunk_attn(m, attn_mask, bias, chunk_size=attn_chunk_size)
+            m = self.layer_norm_m(m)
+            m = self.mha(q=m, k=m, v=m, mask=attn_mask, bias=bias)
 
         return m
 

--- a/unifold/modules/attentions.py
+++ b/unifold/modules/attentions.py
@@ -141,10 +141,13 @@ class GlobalAttention(nn.Module):
         return self.linear_o(o)
 
 
-def gen_msa_attn_mask(mask, inf):
+def gen_msa_attn_mask(mask, inf, gen_col_mask=True):
     row_mask = gen_attn_mask(mask, -inf)[..., :, None, None, :]
-    col_mask = gen_attn_mask(mask.transpose(-1, -2), -inf)[..., :, None, None, :]
-    return row_mask, col_mask
+    if gen_col_mask:
+        col_mask = gen_attn_mask(mask.transpose(-1, -2), -inf)[..., :, None, None, :]
+        return row_mask, col_mask
+    else:
+        return row_mask
 
 
 class MSAAttention(nn.Module):
@@ -180,13 +183,33 @@ class MSAAttention(nn.Module):
         def chunk_forward(m, mask, bias: Optional[torch.Tensor] = None):
             m = self.layer_norm_m(m)
             return self.mha(q=m, k=m, v=m, mask=mask, bias=bias)
-            
+
         return chunk_layer(
             chunk_forward,
             {"m": m, "mask": mask, "bias": bias},
             chunk_size=chunk_size,
             num_batch_dims=len(m.shape[:-2]),
         )
+
+    @torch.jit.ignore
+    def _chunk_attn(
+        self,
+        m: torch.Tensor,
+        mask: Optional[torch.Tensor] = None,
+        bias: Optional[torch.Tensor] = None,
+        chunk_size: Optional[int] = 2560,
+    ) -> torch.Tensor:
+        num_chunk = (m.shape[-3] + chunk_size - 1) // chunk_size
+        outputs = []
+        for i in range(num_chunk):
+            chunk_start = i * chunk_size
+            chunk_end  = min(m.shape[-3], chunk_start + chunk_size)
+            cur_m = m[..., chunk_start: chunk_end , :, :]
+            cur_mask = mask[..., chunk_start: chunk_end, :, :, :] if mask is not None else None
+            outputs.append(
+                self.mha(q=cur_m, k=cur_m, v=cur_m, mask=cur_mask, bias=bias)
+            )
+        return torch.concat(outputs, dim=-3)
 
     def forward(
         self,
@@ -195,7 +218,6 @@ class MSAAttention(nn.Module):
         attn_mask: Optional[torch.Tensor] = None,
         chunk_size: Optional[int] = None,
     ) -> torch.Tensor:
-
 
         bias = None
         if self.pair_bias:
@@ -209,8 +231,12 @@ class MSAAttention(nn.Module):
         if chunk_size is not None:
             m = self._chunk(m, attn_mask, bias, chunk_size)
         else:
+            attn_chunk_size = 2560
             m = self.layer_norm_m(m)
-            m = self.mha(q=m, k=m, v=m, mask=attn_mask, bias=bias)
+            if m.shape[-3] <= attn_chunk_size:
+                m = self.mha(q=m, k=m, v=m, mask=attn_mask, bias=bias)
+            else:
+                return self._chunk_attn(m, attn_mask, bias, chunk_size=attn_chunk_size)
 
         return m
 

--- a/unifold/modules/common.py
+++ b/unifold/modules/common.py
@@ -251,7 +251,7 @@ def fused_bias_gated_dropout_add(
     ) + residual
 
 
-def trimul_residual(
+def tri_mul_residual(
     module,
     residual,
     outputs,

--- a/unifold/modules/common.py
+++ b/unifold/modules/common.py
@@ -77,6 +77,7 @@ class Transition(nn.Module):
         self.linear_2 = Linear(self.n * self.d_in, d_in, init="final")
 
     def _transition(self, x):
+        x = self.layer_norm(x)
         x = self.linear_1(x)
         x = self.act(x)
         x = self.linear_2(x)
@@ -100,8 +101,6 @@ class Transition(nn.Module):
         x: torch.Tensor,
         chunk_size: Optional[int] = None,
     ) -> torch.Tensor:
-
-        x = self.layer_norm(x)
 
         if chunk_size is not None:
             x = self._chunk(x, chunk_size)
@@ -194,8 +193,12 @@ class OuterProductMean(nn.Module):
         return z
 
 
-def residual(residual, x):
-    return x + residual
+def residual(residual, x, training):
+    if training:
+        return x + residual
+    else:
+        residual += x
+        return residual
 
 
 @torch.jit.script
@@ -215,7 +218,8 @@ def fused_bias_dropout_add_inference(
     bias: torch.Tensor,
     residual: torch.Tensor,
 ) -> torch.Tensor:
-    return x + bias + residual
+    residual += bias + x
+    return residual
 
 
 def bias_dropout_residual(module, residual, x, dropout_shared_dim, prob, training):
@@ -259,11 +263,11 @@ def fused_bias_gated_dropout_add_inference(
 
 
 def bias_gated_dropout_residual(
-    module, residual, outputs, dropout_shared_dim, prob, training
+    module, residual, outputs, dropout_shared_dim, prob, training, chunk_size=None,
 ):
-    x, g = outputs
-    bias, g_bias = module.get_output_bias()
-    if training:
+    if training or chunk_size is None:
+        x, g = outputs
+        bias, g_bias = module.get_output_bias()
         shape = list(x.shape)
         shape[dropout_shared_dim] = 1
         with torch.no_grad():
@@ -278,7 +282,9 @@ def bias_gated_dropout_residual(
             prob,
         )
     else:
-        return fused_bias_gated_dropout_add_inference(x, bias, g, g_bias, residual)
+        # gated is not used here
+        residual += outputs
+        return residual
 
 
 class SimpleModuleList(nn.ModuleList):

--- a/unifold/modules/common.py
+++ b/unifold/modules/common.py
@@ -251,19 +251,14 @@ def fused_bias_gated_dropout_add(
     ) + residual
 
 
-@torch.jit.script
-def fused_bias_gated_dropout_add_inference(
-    x: torch.Tensor,
-    bias: torch.Tensor,
-    g: torch.Tensor,
-    g_bias: torch.Tensor,
-    residual: torch.Tensor,
-) -> torch.Tensor:
-    return (torch.sigmoid(g + g_bias) * (x + bias)) + residual
-
-
-def bias_gated_dropout_residual(
-    module, residual, outputs, dropout_shared_dim, prob, training, chunk_size=None,
+def trimul_residual(
+    module,
+    residual,
+    outputs,
+    dropout_shared_dim,
+    prob,
+    training,
+    chunk_size=None,
 ):
     if training or chunk_size is None:
         x, g = outputs

--- a/unifold/modules/evoformer.py
+++ b/unifold/modules/evoformer.py
@@ -120,7 +120,7 @@ class EvoformerIteration(nn.Module):
         msa_mask: torch.Tensor,
         pair_mask: torch.Tensor,
         msa_row_attn_mask: torch.Tensor,
-        msa_col_attn_mask: torch.Tensor,
+        msa_col_attn_mask: Optional[torch.Tensor],
         tri_start_attn_mask: torch.Tensor,
         tri_end_attn_mask: torch.Tensor,
         chunk_size: Optional[int] = None,

--- a/unifold/modules/evoformer.py
+++ b/unifold/modules/evoformer.py
@@ -10,7 +10,7 @@ from .common import (
     SimpleModuleList,
     residual,
     bias_dropout_residual,
-    bias_gated_dropout_residual,
+    trimul_residual,
 )
 from .attentions import (
     MSARowAttentionWithPairBias,
@@ -166,7 +166,7 @@ class EvoformerIteration(nn.Module):
                 self.training
             )
 
-        z = bias_gated_dropout_residual(
+        z = trimul_residual(
             self.tri_mul_out,
             z,
             self.tri_mul_out(z, mask=pair_mask, chunk_size=chunk_size),
@@ -176,7 +176,7 @@ class EvoformerIteration(nn.Module):
             chunk_size=chunk_size,
         )
 
-        z = bias_gated_dropout_residual(
+        z = trimul_residual(
             self.tri_mul_in,
             z,
             self.tri_mul_in(z, mask=pair_mask, chunk_size=chunk_size),

--- a/unifold/modules/evoformer.py
+++ b/unifold/modules/evoformer.py
@@ -120,7 +120,7 @@ class EvoformerIteration(nn.Module):
         msa_mask: torch.Tensor,
         pair_mask: torch.Tensor,
         msa_row_attn_mask: torch.Tensor,
-        msa_col_attn_mask: Optional[torch.Tensor],
+        msa_col_attn_mask: torch.Tensor,
         tri_start_attn_mask: torch.Tensor,
         tri_end_attn_mask: torch.Tensor,
         chunk_size: Optional[int] = None,
@@ -128,7 +128,8 @@ class EvoformerIteration(nn.Module):
 
         if self.outer_product_mean_first:
             z = residual(
-                z, self.outer_product_mean(m, mask=msa_mask, chunk_size=chunk_size)
+                z, self.outer_product_mean(m, mask=msa_mask, chunk_size=chunk_size),
+                self.training
             )
 
         m = bias_dropout_residual(
@@ -142,7 +143,10 @@ class EvoformerIteration(nn.Module):
             self.training,
         )
         if self._is_extra_msa_stack:
-            m = residual(m, self.msa_att_col(m, mask=msa_mask, chunk_size=chunk_size))
+            m = residual(
+                m, self.msa_att_col(m, mask=msa_mask, chunk_size=chunk_size),
+                self.training
+            )
         else:
             m = bias_dropout_residual(
                 self.msa_att_col,
@@ -152,28 +156,34 @@ class EvoformerIteration(nn.Module):
                 self.msa_dropout,
                 self.training,
             )
-        m = residual(m, self.msa_transition(m, chunk_size=chunk_size))
+        m = residual(
+            m, self.msa_transition(m, chunk_size=chunk_size),
+            self.training
+        )
         if not self.outer_product_mean_first:
             z = residual(
-                z, self.outer_product_mean(m, mask=msa_mask, chunk_size=chunk_size)
+                z, self.outer_product_mean(m, mask=msa_mask, chunk_size=chunk_size),
+                self.training
             )
 
         z = bias_gated_dropout_residual(
             self.tri_mul_out,
             z,
-            self.tri_mul_out(z, mask=pair_mask),
+            self.tri_mul_out(z, mask=pair_mask, chunk_size=chunk_size),
             self.row_dropout_share_dim,
             self.pair_dropout,
             self.training,
+            chunk_size=chunk_size,
         )
 
         z = bias_gated_dropout_residual(
             self.tri_mul_in,
             z,
-            self.tri_mul_in(z, mask=pair_mask),
+            self.tri_mul_in(z, mask=pair_mask, chunk_size=chunk_size),
             self.row_dropout_share_dim,
             self.pair_dropout,
             self.training,
+            chunk_size=chunk_size,
         )
 
         z = bias_dropout_residual(
@@ -193,7 +203,10 @@ class EvoformerIteration(nn.Module):
             self.pair_dropout,
             self.training,
         )
-        z = residual(z, self.pair_transition(z, chunk_size=chunk_size))
+        z = residual(
+            z, self.pair_transition(z, chunk_size=chunk_size),
+            self.training
+        )
         return m, z
 
 

--- a/unifold/modules/evoformer.py
+++ b/unifold/modules/evoformer.py
@@ -10,7 +10,7 @@ from .common import (
     SimpleModuleList,
     residual,
     bias_dropout_residual,
-    trimul_residual,
+    tri_mul_residual,
 )
 from .attentions import (
     MSARowAttentionWithPairBias,
@@ -166,7 +166,7 @@ class EvoformerIteration(nn.Module):
                 self.training
             )
 
-        z = trimul_residual(
+        z = tri_mul_residual(
             self.tri_mul_out,
             z,
             self.tri_mul_out(z, mask=pair_mask, chunk_size=chunk_size),
@@ -176,7 +176,7 @@ class EvoformerIteration(nn.Module):
             chunk_size=chunk_size,
         )
 
-        z = trimul_residual(
+        z = tri_mul_residual(
             self.tri_mul_in,
             z,
             self.tri_mul_in(z, mask=pair_mask, chunk_size=chunk_size),

--- a/unifold/modules/template.py
+++ b/unifold/modules/template.py
@@ -9,7 +9,7 @@ from .common import (
     SimpleModuleList,
     residual,
     bias_dropout_residual,
-    trimul_residual,
+    tri_mul_residual,
 )
 from .common import Linear, Transition, chunk_layer
 from .attentions import (
@@ -179,7 +179,7 @@ class TemplatePairStackBlock(nn.Module):
                 self.dropout,
                 self.training,
             )
-            s = trimul_residual(
+            s = tri_mul_residual(
                 self.tri_mul_out,
                 s,
                 self.tri_mul_out(s, mask=mask),
@@ -188,7 +188,7 @@ class TemplatePairStackBlock(nn.Module):
                 self.training,
             )
 
-            s = trimul_residual(
+            s = tri_mul_residual(
                 self.tri_mul_in,
                 s,
                 self.tri_mul_in(s, mask=mask),
@@ -197,7 +197,7 @@ class TemplatePairStackBlock(nn.Module):
                 self.training,
             )
         else:
-            s = trimul_residual(
+            s = tri_mul_residual(
                 self.tri_mul_out,
                 s,
                 self.tri_mul_out(s, mask=mask),
@@ -206,7 +206,7 @@ class TemplatePairStackBlock(nn.Module):
                 self.training,
             )
 
-            s = trimul_residual(
+            s = tri_mul_residual(
                 self.tri_mul_in,
                 s,
                 self.tri_mul_in(s, mask=mask),

--- a/unifold/modules/template.py
+++ b/unifold/modules/template.py
@@ -240,6 +240,7 @@ class TemplatePairStackBlock(nn.Module):
                 s,
                 chunk_size=chunk_size,
             ),
+            self.training
         )
         return s
 

--- a/unifold/modules/template.py
+++ b/unifold/modules/template.py
@@ -9,7 +9,7 @@ from .common import (
     SimpleModuleList,
     residual,
     bias_dropout_residual,
-    bias_gated_dropout_residual,
+    trimul_residual,
 )
 from .common import Linear, Transition, chunk_layer
 from .attentions import (
@@ -179,7 +179,7 @@ class TemplatePairStackBlock(nn.Module):
                 self.dropout,
                 self.training,
             )
-            s = bias_gated_dropout_residual(
+            s = trimul_residual(
                 self.tri_mul_out,
                 s,
                 self.tri_mul_out(s, mask=mask),
@@ -188,7 +188,7 @@ class TemplatePairStackBlock(nn.Module):
                 self.training,
             )
 
-            s = bias_gated_dropout_residual(
+            s = trimul_residual(
                 self.tri_mul_in,
                 s,
                 self.tri_mul_in(s, mask=mask),
@@ -197,7 +197,7 @@ class TemplatePairStackBlock(nn.Module):
                 self.training,
             )
         else:
-            s = bias_gated_dropout_residual(
+            s = trimul_residual(
                 self.tri_mul_out,
                 s,
                 self.tri_mul_out(s, mask=mask),
@@ -206,7 +206,7 @@ class TemplatePairStackBlock(nn.Module):
                 self.training,
             )
 
-            s = bias_gated_dropout_residual(
+            s = trimul_residual(
                 self.tri_mul_in,
                 s,
                 self.tri_mul_in(s, mask=mask),

--- a/unifold/modules/triangle_multiplication.py
+++ b/unifold/modules/triangle_multiplication.py
@@ -27,8 +27,7 @@ class TriangleMultiplication(nn.Module):
 
         self._alphafold_original_mode = False
 
-
-    def _chunk2D(
+    def _chunk_2d(
         self,
         z: torch.Tensor,
         mask: Optional[torch.Tensor] = None,
@@ -41,10 +40,12 @@ class TriangleMultiplication(nn.Module):
         dim1 = z.shape[-3]
 
         def _slice_linear(z, linear: Linear, a=True):
-            d_hid = linear.bias.shape[0]//2
+            d_hid = linear.bias.shape[0] // 2
             index = 0 if a else d_hid
-            p = nn.functional.linear(z,
-                    linear.weight[index: index + d_hid]) + linear.bias[index: index + d_hid]
+            p = (
+                nn.functional.linear(z, linear.weight[index : index + d_hid])
+                + linear.bias[index : index + d_hid]
+            )
             return p
 
         def _chunk_projection(z, mask, a=True):
@@ -58,15 +59,17 @@ class TriangleMultiplication(nn.Module):
             chunk_end = min(chunk_start + chunk_size, dim1)
             if self.outgoing:
                 a_chunk = _chunk_projection(
-                                z[..., chunk_start: chunk_end, :, :],
-                                mask[..., chunk_start: chunk_end, :, :],
-                                a=True)
+                    z[..., chunk_start:chunk_end, :, :],
+                    mask[..., chunk_start:chunk_end, :, :],
+                    a=True,
+                )
                 a_chunk = permute_final_dims(a_chunk, (2, 0, 1))
             else:
                 a_chunk = _chunk_projection(
-                                z[..., :, chunk_start: chunk_end, :],
-                                mask[...,:, chunk_start: chunk_end, :],
-                                a=True)
+                    z[..., :, chunk_start:chunk_end, :],
+                    mask[..., :, chunk_start:chunk_end, :],
+                    a=True,
+                )
                 a_chunk = a_chunk.transpose(-1, -3)
 
             for j in range(num_chunk):
@@ -74,29 +77,40 @@ class TriangleMultiplication(nn.Module):
                 j_chunk_end = min(j_chunk_start + chunk_size, dim1)
                 if self.outgoing:
                     b_chunk = _chunk_projection(
-                                z[..., j_chunk_start: j_chunk_end, :, :],
-                                mask[..., j_chunk_start: j_chunk_end, :, :],
-                                a=False)
+                        z[..., j_chunk_start:j_chunk_end, :, :],
+                        mask[..., j_chunk_start:j_chunk_end, :, :],
+                        a=False,
+                    )
                     b_chunk = b_chunk.transpose(-1, -3)
                 else:
                     b_chunk = _chunk_projection(
-                                z[..., :, j_chunk_start: j_chunk_end, :],
-                                mask[..., :, j_chunk_start: j_chunk_end, :],
-                                a=False)
+                        z[..., :, j_chunk_start:j_chunk_end, :],
+                        mask[..., :, j_chunk_start:j_chunk_end, :],
+                        a=False,
+                    )
                     b_chunk = permute_final_dims(b_chunk, (2, 0, 1))
                 x_chunk = torch.matmul(a_chunk, b_chunk)
                 del b_chunk
                 x_chunk = permute_final_dims(x_chunk, (1, 2, 0))
                 x_chunk = self.layer_norm_out(x_chunk)
                 x_chunk = self.linear_z(x_chunk)
-                x_chunk *= torch.sigmoid(self.linear_g(z[..., chunk_start: chunk_end, j_chunk_start: j_chunk_end, :]))
-                new_z[..., chunk_start: chunk_end, j_chunk_start: j_chunk_end, :] = x_chunk
+                x_chunk *= torch.sigmoid(
+                    self.linear_g(
+                        z[..., chunk_start:chunk_end, j_chunk_start:j_chunk_end, :]
+                    )
+                )
+                new_z[
+                    ..., chunk_start:chunk_end, j_chunk_start:j_chunk_end, :
+                ] = x_chunk
                 del x_chunk
             del a_chunk
         return new_z
 
     def forward(
-        self, z: torch.Tensor, mask: Optional[torch.Tensor] = None, chunk_size = None,
+        self,
+        z: torch.Tensor,
+        mask: Optional[torch.Tensor] = None,
+        chunk_size=None,
     ) -> torch.Tensor:
 
         mask = mask.unsqueeze(-1)
@@ -106,7 +120,7 @@ class TriangleMultiplication(nn.Module):
 
         z = self.layer_norm_in(z)
         if not self.training and chunk_size is not None:
-            return self._chunk2D(z, mask, chunk_size=chunk_size)
+            return self._chunk_2d(z, mask, chunk_size=chunk_size)
 
         g = nn.functional.linear(z, self.linear_g.weight)
         ab = self.linear_ab_p(z) * mask

--- a/unifold/modules/triangle_multiplication.py
+++ b/unifold/modules/triangle_multiplication.py
@@ -2,7 +2,7 @@ from functools import partialmethod
 from typing import Optional, List
 import torch
 import torch.nn as nn
-from .common import Linear, fused_bias_gated_dropout_add_inference
+from .common import Linear
 from unicore.utils import (
     permute_final_dims,
 )


### PR DESCRIPTION
1 add the inplace-style residual modules for inference
2 change the order of layer_norm_in while chunked inference
3 add the chunk2d style inference forward for /triangle_multiplication 