### PR TITLE
change the definition of target name

### DIFF
--- a/run_unifold.sh
+++ b/run_unifold.sh
@@ -14,15 +14,15 @@ python unifold/homo_search.py \
     --mgnify_database_path=$database_dir/mgnify/mgy_clusters_2018_12.fa \
     --bfd_database_path=$database_dir/bfd/bfd_metaclust_clu_complete_id30_c90_final_seq.sorted_opt \
     --uniclust30_database_path=$database_dir/uniclust30/uniclust30_2018_08/uniclust30_2018_08 \
-    --uniprot_database_path=$database_dir/uniprot_db/uniprot_220501/uniprot_trembl.fasta \
+    --uniprot_database_path=$database_dir/uniprot/uniprot.fasta \
     --pdb_seqres_database_path=$database_dir/pdb_seqres/pdb_seqres.txt \
     --template_mmcif_dir=$database_dir/pdb_mmcif/mmcif_files \
     --obsolete_pdbs_path=$database_dir/pdb_mmcif/obsolete.dat \
     --use_precomputed_msas=True
 
 echo "Starting prediction..."
-fasta_dir=$(dirname $fasta_path)
-target_name=${fasta_dir##*/}
+fasta_file=$(basename $fasta_path)
+target_name=${fasta_file%.fa*}
 python unifold/inference.py \
 	--model_name=$model_name \
 	--param_path=$param_path \

--- a/unifold/homo_search.py
+++ b/unifold/homo_search.py
@@ -17,6 +17,7 @@
 import json
 import os
 import pickle
+from pathlib import Path
 import shutil
 import time
 import gzip
@@ -261,7 +262,7 @@ def main(argv):
     )
 
     fasta_path = FLAGS.fasta_path
-    fasta_name = FLAGS.fasta_path.split("/")[-2]
+    fasta_name = Path(fasta_path).stem
     input_fasta_str = open(fasta_path).read()
     input_seqs, input_descs = parsers.parse_fasta(input_fasta_str)
     if len(input_seqs) > 1:


### PR DESCRIPTION
change the definition of target name, which will directly depends on fasta file. It will be more convenient for user. 
Old version:
`fasta_path=foo/bar/abcd.fasta`
fasta_name will be `bar`

New version:
`fasta_path=foo/bar/abcd.fasta`
fasta_name will be `abcd`