### PR TITLE
Flash v2 

### DIFF
--- a/train_monomer_demo.sh
+++ b/train_monomer_demo.sh
@@ -2,15 +2,16 @@
 [ -z "${n_gpu}" ] && n_gpu=$(nvidia-smi -L | wc -l)
 export NCCL_ASYNC_ERROR_HANDLING=1
 export OMP_NUM_THREADS=1
-mkdir -p $1
+mkdir -p temp
 tmp_dir=`mktemp -d`
-python -m torch.distributed.launch --nproc_per_node=$n_gpu --master_port $MASTER_PORT $(which unicore-train) ./example_data/  --user-dir unifold \
+# --tensorboard-logdir $1/tsb/
+torchrun --nproc_per_node=$n_gpu --master_port $MASTER_PORT $(which unicore-train) ./example_data/  --user-dir unifold \
        --num-workers 8 --ddp-backend=no_c10d \
        --task af2 --loss af2 --arch af2 \
        --optimizer adam --adam-betas '(0.9, 0.999)' --adam-eps 1e-6 --clip-norm 0.0  --per-sample-clip-norm 0.1 --allreduce-fp32-grad  \
-       --lr-scheduler exponential_decay --lr 1e-3 --warmup-updates 1000 --decay-ratio 0.95 --decay-steps 50000 --batch-size 1 \
-       --update-freq 1 --seed 42  --tensorboard-logdir $1/tsb/ \
-       --max-update 1000 --max-epoch 1 --log-interval 10 --log-format simple \
+       --lr-scheduler exponential_decay --lr 1e-3 --warmup-updates 10 --decay-ratio 0.95 --decay-steps 50000 --batch-size 1 \
+       --update-freq 1 --seed 42 \
+       --max-update 1000 --max-epoch 1 --log-interval 1 --log-format tqdm \
        --save-interval-updates 100 --validate-interval-updates 100 --keep-interval-updates 5 --no-epoch-checkpoints  \
-       --save-dir $1 --tmp-save-dir $tmp_dir --required-batch-size-multiple 1 --ema-decay 0.999  --bf16 --bf16-sr # for V100 or older GPUs, you can disable --bf16 for faster speed.
+       --save-dir temp --tmp-save-dir $tmp_dir --required-batch-size-multiple 1 --ema-decay 0.999  --fp16 # --bf16 --bf16-sr # for V100 or older GPUs, you can disable --bf16 for faster speed.
 rm -rf $tmp_dir


### PR DESCRIPTION
Uses flash attention v2. Works for any sequence length. 
* Flash attn v2 from pytorch for masked attention. 
* Custom flash attn v2 kernel for bias (triton-based, currently block size decided by autotuner, might need improvements to avoid recompilation). 
    * TF32 acceleration disabled by default, might need to check compute architecture and selectively enable it.   

WARNING! Pls install the custom fork from [trident](https://github.com/kakaobrain/trident) provided below as a zip file. You might need to install `triton-nightly` afterwards (maybe also `nvtx`) to get it working (see [triton repo](https://github.com/openai/triton/#quick-installation) for instructions). Check with `ipython; import trident as td`

[trident.zip](https://github.com/dptech-corp/Uni-Fold/files/13061121/trident.zip)
